### PR TITLE
Updates to FV2AuthPlugin recipe

### DIFF
--- a/FV2AuthPlugin/FV2AuthPlugin.download.recipe
+++ b/FV2AuthPlugin/FV2AuthPlugin.download.recipe
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads FV2AuthPlugin DMG.</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.robperc-recipes.download.FV2AuthPlugin</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>FV2AuthPlugin</string>
+		<key>GITHUB_REPO</key>
+		<string>tburgin/FV2AuthPlugin</string>
+	</dict>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
+			<key>Arguments</key>
+			<dict>
+				<key>github_repo</key>
+				<string>%GITHUB_REPO%</string>
+				<key>asset_regex</key>
+				<string>.*dmg</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/FV2AuthPlugin/FV2AuthPlugin.munki.recipe
+++ b/FV2AuthPlugin/FV2AuthPlugin.munki.recipe
@@ -2,61 +2,66 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads FV2AuthPlugin dmg and imports into Munki.</string>
-    <key>Identifier</key>
-    <string>com.github.robperc.munki.FV2AuthPlugin</string>
-    <key>Input</key>
-    <dict>
-        <key>MUNKI_REPO_SUBDIR</key>
-        <string>apps</string>
-        <key>NAME</key>
-        <string>FV2AuthPlugin</string>
-        <key>pkginfo</key>
-        <dict>
+	<key>Description</key>
+	<string>Downloads FV2AuthPlugin dmg and imports into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.robperc.munki.FV2AuthPlugin</string>
+	<key>ParentRecipe</key>
+	<string>com.github.autopkg.robperc-recipes.download.FV2AuthPlugin</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps</string>
+		<key>NAME</key>
+		<string>FV2AuthPlugin</string>
+		<key>pkginfo</key>
+		<dict>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>display_name</key>
+			<string>File Vault 2 Authorization Plugin</string>
 			<key>description</key>
 			<string>Automatic FV2 User Enrollment at the Login Window.</string>
+			<key>minimum_os_version</key>
+			<string>10.6.0</string>
+			<key>unattended_install</key>
+			<true/>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
 		</dict>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.2.0</string>
-    <key>Process</key>
-    <array>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>Process</key>
+	<array>
 		<dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>FlatPkgUnpacker</string>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>https://github.com/tburgin/FV2AuthPlugin/releases</string>
-				<key>re_pattern</key>
-				<string>(?P&lt;path&gt;/tburgin/FV2AuthPlugin/releases/download/[^/]*/FV2AuthPlugin-Installer-[^"]*)</string>
+				<key>flat_pkg_path</key>
+				<string>%pathname%/*Uninstaller*.pkg</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/uninstaller-unpack</string>
 			</dict>
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>URLDownloader</string>
+			<string>MunkiImporter</string>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>https://github.com%path%</string>
-				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>additional_makepkginfo_options</key>
+				<array>
+					<string>--uninstall_script=%RECIPE_CACHE_DIR%/uninstaller-unpack/Scripts/postinstall</string>
+				</array>
 			</dict>
 		</dict>
-        <dict>
-	        <key>Processor</key>
-	        <string>MunkiImporter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_path</key>
-                <string>%pathname%</string>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-            </dict>
-        </dict>
-    </array>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
- split download recipes from Munki recipe
- use [GitHub release info provider](https://github.com/autopkg/autopkg/wiki/Processor-GitHubReleasesInfoProvider)
- add uninstall script (from separate but included package)
- modify munki pkginfo
