### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Processors/CmDistributionModifier.py
+++ b/Processors/CmDistributionModifier.py
@@ -66,23 +66,23 @@ XML = """<?xml version="1.0" encoding="utf-8" standalone="no"?>
         <search id="pkmktoken24-0" type="script" script="pkmktoken24_combined()">
             <script>
 function pkmktoken24_combined() {
-	function pkmk_add_results_to_array(results, array) {
-		for(i = 0; i &lt; results.length; i++)
-			array.push(results[i]);
-	}
-	var result = new Array();
-	var search;
-	search = my.search.results['pkmktoken24-1'];
-	if(search) pkmk_add_results_to_array(search, result);
-	return result;
+    function pkmk_add_results_to_array(results, array) {
+        for(i = 0; i &lt; results.length; i++)
+            array.push(results[i]);
+    }
+    var result = new Array();
+    var search;
+    search = my.search.results['pkmktoken24-1'];
+    if(search) pkmk_add_results_to_array(search, result);
+    return result;
 }
 </script>
         </search>
         <search type="script" id="pkmktoken24" script="pkmktoken24_final()">
             <script>
 function pkmktoken24_final() {
-	var combined = my.search.results['pkmktoken24-0'];
-	return combined;
+    var combined = my.search.results['pkmktoken24-0'];
+    return combined;
 }
 </script>
         </search>
@@ -102,9 +102,9 @@ class CmDistributionModifier(Processor):
         },
     }
     output_variables = {}
-    
+
     __doc__ = description
-    
+
     def main(self):
         # Determine base_url, version, product_name.
         filename = self.env["distribution"]
@@ -114,7 +114,7 @@ class CmDistributionModifier(Processor):
         f.truncate()
         f.close()
         self.output("Distribution file overwritten")
-    
+
 
 if __name__ == "__main__":
     processor = CmDistributionModifier()

--- a/Processors/CmDistributionModifier.py
+++ b/Processors/CmDistributionModifier.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import re
 
 from autopkglib import Processor, ProcessorError
 

--- a/Processors/CmDistributionModifier.py
+++ b/Processors/CmDistributionModifier.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 
 from autopkglib import Processor, ProcessorError

--- a/Processors/FileChecksummer.py
+++ b/Processors/FileChecksummer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 import os
 import hashlib

--- a/Processors/FileChecksummer.py
+++ b/Processors/FileChecksummer.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
-import os
+
 import hashlib
+import os
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["FileChecksummer"]
 

--- a/Processors/IconImporter.py
+++ b/Processors/IconImporter.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 sys.path.append('/usr/local/munki')
 import os
@@ -194,12 +196,12 @@ def generate_pngs_from_munki_items(repo_path, force=False, itemlist=None):
 
 def print_utf8(text):
     '''Print Unicode text as UTF-8'''
-    print text.encode('UTF-8')
+    print(text.encode('UTF-8'))
 
 
 def print_err_utf8(text):
     '''Print Unicode text to stderr as UTF-8'''
-    print >> sys.stderr, text.encode('UTF-8')
+    print(text.encode('UTF-8'), file=sys.stderr)
 
 
 def pref(prefname):

--- a/Processors/IconImporter.py
+++ b/Processors/IconImporter.py
@@ -15,16 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
-import sys
-sys.path.append('/usr/local/munki')
+from __future__ import absolute_import, print_function
+
 import os
-from optparse import OptionParser
-from munkilib import munkicommon
-from munkilib import FoundationPlist
-from munkilib import iconutils
+import sys
+
 from autopkglib import Processor, ProcessorError
+
+sys.path.append('/usr/local/munki')
+from munkilib import FoundationPlist, iconutils, munkicommon
 
 __all__ = ["IconImporter"]
 
@@ -33,12 +32,12 @@ class IconImporter(Processor):
     input_variables = {
         "MUNKI_REPO": {
             "required": True,
-            "description": 
+            "description":
                 "Path to target repo.",
         },
         "name": {
             "required": True,
-            "description": 
+            "description":
                 "Name of target to fetch icon(s) for. Should correspond to value of name key in pkginfo",
         },
         "force": {
@@ -50,7 +49,7 @@ class IconImporter(Processor):
     output_variables = {}
 
     __doc__ = description
-    
+
     def main(self):
         repo = self.env["MUNKI_REPO"]
         name = self.env["name"]
@@ -63,15 +62,15 @@ class IconImporter(Processor):
         munkicommon.cleanUpTmpDir()
 
 """
-The following code is from Greg Neagle's iconimporter tool. 
-Unfortunately it is not currently packaged by default with 
+The following code is from Greg Neagle's iconimporter tool.
+Unfortunately it is not currently packaged by default with
 munkitools so I can't import it from there like the rest of the
 modules...
 """
 
 PREFSNAME = 'com.googlecode.munki.munkiimport.plist'
 PREFSPATH = os.path.expanduser(os.path.join(u'~/Library/Preferences', PREFSNAME))
-        
+
 def generate_png_from_copy_from_dmg_item(install_item, repo_path):
     dmgpath = os.path.join(
         repo_path, 'pkgs', install_item['installer_item_location'])
@@ -146,7 +145,7 @@ def generate_pngs_from_installer_pkg(install_item, repo_path):
             index += 1
     else:
         print_utf8(u'\tNo application icons found.')
-        
+
 
 def findItemsToCheck(repo_path, itemlist=None):
     '''Builds a list of items to check; only the latest version

--- a/Processors/IconImporter.py
+++ b/Processors/IconImporter.py
@@ -207,7 +207,7 @@ def pref(prefname):
     """Returns a preference for prefname"""
     try:
         _prefs = FoundationPlist.readPlist(PREFSPATH)
-    except BaseException:
+    except Exception:
         return None
     if prefname in _prefs:
         return _prefs[prefname]

--- a/Processors/IconImporter.py
+++ b/Processors/IconImporter.py
@@ -208,7 +208,7 @@ def pref(prefname):
     """Returns a preference for prefname"""
     try:
         _prefs = FoundationPlist.readPlist(PREFSPATH)
-    except Exception:
+    except BaseException:
         return None
     if prefname in _prefs:
         return _prefs[prefname]

--- a/Processors/ItemSizer.py
+++ b/Processors/ItemSizer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 import os
 

--- a/Processors/ItemSizer.py
+++ b/Processors/ItemSizer.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
+from __future__ import absolute_import, division
+
 import os
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["ItemSizer"]
 
@@ -19,12 +21,12 @@ class ItemSizer(Processor):
             "description": "Size of specified item in kibibytes (KiB).",
         },
     }
-    
+
     __doc__ = description
-    
+
     def main(self):
         item_path = self.env["item_path"]
-        
+
         self.env["item_size"] = str(os.path.getsize(item_path) / 1024)
 
 if __name__ == "__main__":

--- a/Processors/JsonReader.py
+++ b/Processors/JsonReader.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 import json
 

--- a/Processors/JsonReader.py
+++ b/Processors/JsonReader.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
+
 import json
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["JsonReader"]
 

--- a/Processors/KyngChaosURLProvider.py
+++ b/Processors/KyngChaosURLProvider.py
@@ -17,10 +17,13 @@
 
 from __future__ import absolute_import
 import re
-import urllib2
 
 from autopkglib import Processor, ProcessorError
 
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["KyngChaosURLProvider"]
 
@@ -32,7 +35,7 @@ class KyngChaosURLProvider(Processor):
     input_variables = {
         "product_name": {
             "required": True,
-            "description": 
+            "description":
                 "Product to fetch URL for. One of 'qgis', 'gdal', 'numpy', 'matplolib.",
         },
         "version": {
@@ -50,13 +53,13 @@ class KyngChaosURLProvider(Processor):
             "description": "URL to the latest KyngChaos download release.",
         },
     }
-    
+
     __doc__ = description
-    
+
     def get_kyngchaos_dmg_url(self, base_url, product_name, version):
-        
+
         product_dir = ''
-        
+
 		# Expand product name to full product name (IE: gdal -> GDAL_Complete)
 		# and get product directory from product type
         if product_name == 'qgis':
@@ -70,62 +73,62 @@ class KyngChaosURLProvider(Processor):
             product_name = 'NumPy'
         elif product_name == 'matplotlib':
             product_dir = 'python'
-        
+
         else:
             raise ValueError('product name not recognized')
-            
+
         if version == 'latest':
             version = self.get_latest_version(product_name, product_dir)
-        
-        filename = product_name + '-' + version + '.dmg'   
-        
+
+        filename = product_name + '-' + version + '.dmg'
+
 		# Construct download URL.
         dmg_url = "/".join((base_url, product_dir, filename))
-        
+
         # Try to open download link.
         try:
-            f = urllib2.urlopen(dmg_url)
+            f = urlopen(dmg_url)
             f.close()
         except BaseException as e:
             raise ProcessorError("Can't download %s: %s" % (dmg_url, e))
-        
+
         # Return URL.
         return dmg_url
-    
+
     def get_latest_version(self, product_name, product_dir):
-    
+
         # Read HTML index.
         index_url = "http://www.kyngchaos.com/software/" + product_dir
         try:
-            f = urllib2.urlopen(index_url)
+            f = urlopen(index_url)
             html = f.read()
             f.close()
         except BaseException as e:
             raise ProcessorError("Can't open %s: %s" % (index_url, e))
-        
+
         # Create regex for finding newest version
         regex = re.escape(product_name) + r'-(?P<version>[^"]+)\.dmg"'
         re_dmg = re.compile(regex)
-        
+
         # Search for newest version
         m = re_dmg.search(html)
         if not m:
             raise ProcessorError(
-                "Couldn't find %s download URL in %s" 
+                "Couldn't find %s download URL in %s"
                 % (product_name, index_url))
         # Return version
         return m.group('version')
-        
-    
+
+
     def main(self):
         # Determine base_url, version, product_name.
         product_name = self.env["product_name"]
         version = self.env.get("version", "latest")
         base_url = self.env.get("base_url", KYNGCHAOS_BASE_URL)
-        
+
         self.env["url"] = self.get_kyngchaos_dmg_url(base_url, product_name, version)
         self.output("Found URL %s" % self.env["url"])
-    
+
 
 if __name__ == "__main__":
     processor = KyngChaosURLProvider()

--- a/Processors/KyngChaosURLProvider.py
+++ b/Processors/KyngChaosURLProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import re
 import urllib2
 

--- a/Processors/KyngChaosURLProvider.py
+++ b/Processors/KyngChaosURLProvider.py
@@ -60,8 +60,8 @@ class KyngChaosURLProvider(Processor):
 
         product_dir = ''
 
-		# Expand product name to full product name (IE: gdal -> GDAL_Complete)
-		# and get product directory from product type
+        # Expand product name to full product name (IE: gdal -> GDAL_Complete)
+        # and get product directory from product type
         if product_name == 'qgis':
             product_dir = product_name
             product_name = product_name.upper()
@@ -82,7 +82,7 @@ class KyngChaosURLProvider(Processor):
 
         filename = product_name + '-' + version + '.dmg'
 
-		# Construct download URL.
+        # Construct download URL.
         dmg_url = "/".join((base_url, product_dir, filename))
 
         # Try to open download link.

--- a/Processors/KyngChaosURLProvider.py
+++ b/Processors/KyngChaosURLProvider.py
@@ -16,6 +16,7 @@
 
 
 from __future__ import absolute_import
+
 import re
 
 from autopkglib import Processor, ProcessorError

--- a/Processors/KyngChaosURLProvider.py
+++ b/Processors/KyngChaosURLProvider.py
@@ -90,7 +90,7 @@ class KyngChaosURLProvider(Processor):
         try:
             f = urlopen(dmg_url)
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't download %s: %s" % (dmg_url, e))
 
         # Return URL.
@@ -104,7 +104,7 @@ class KyngChaosURLProvider(Processor):
             f = urlopen(index_url)
             html = f.read()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't open %s: %s" % (index_url, e))
 
         # Create regex for finding newest version

--- a/Processors/KyngChaosURLProvider.py
+++ b/Processors/KyngChaosURLProvider.py
@@ -19,19 +19,14 @@ from __future__ import absolute_import
 
 import re
 
-from autopkglib import Processor, ProcessorError
-
-try:
-    from urllib.parse import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
+from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["KyngChaosURLProvider"]
 
 
 KYNGCHAOS_BASE_URL = "http://www.kyngchaos.com/files/software"
 
-class KyngChaosURLProvider(Processor):
+class KyngChaosURLProvider(URLGetter):
     description = "Provides URL to the latest KyngChaos downloads."
     input_variables = {
         "product_name": {
@@ -86,13 +81,6 @@ class KyngChaosURLProvider(Processor):
         # Construct download URL.
         dmg_url = "/".join((base_url, product_dir, filename))
 
-        # Try to open download link.
-        try:
-            f = urlopen(dmg_url)
-            f.close()
-        except Exception as e:
-            raise ProcessorError("Can't download %s: %s" % (dmg_url, e))
-
         # Return URL.
         return dmg_url
 
@@ -100,12 +88,7 @@ class KyngChaosURLProvider(Processor):
 
         # Read HTML index.
         index_url = "http://www.kyngchaos.com/software/" + product_dir
-        try:
-            f = urlopen(index_url)
-            html = f.read()
-            f.close()
-        except Exception as e:
-            raise ProcessorError("Can't open %s: %s" % (index_url, e))
+        html = self.download(index_url, text=True)
 
         # Create regex for finding newest version
         regex = re.escape(product_name) + r'-(?P<version>[^"]+)\.dmg"'

--- a/Processors/RhinoURLProvider.py
+++ b/Processors/RhinoURLProvider.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import re
 
 from autopkglib import Processor, ProcessorError
 
@@ -35,9 +34,9 @@ class RhinoURLProvider(Processor):
             "description": "URL to the latest Rhino release download.",
         },
     }
-    
+
     __doc__ = description
-    
+
     def main(self):
         # Determine base_url, version, product_name.
         release_url = self.env["release_url"]
@@ -47,7 +46,7 @@ class RhinoURLProvider(Processor):
         major = str(float('.'.join(version.split('.')[:-1])))
         url = "http://files.mcneel.com/Releases/Rhino/MAJOR/Mac/Rhinoceros_VERSION.dmg".replace("MAJOR", major).replace("VERSION", version)
         self.env["rhino_url"] = url
-    
+
 
 if __name__ == "__main__":
     processor = RhinoURLProvider()

--- a/Processors/RhinoURLProvider.py
+++ b/Processors/RhinoURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 
 from autopkglib import Processor, ProcessorError

--- a/Processors/Sha256Summer.py
+++ b/Processors/Sha256Summer.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
+
 import hashlib
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["Sha256Summer"]
 

--- a/Processors/Sha256Summer.py
+++ b/Processors/Sha256Summer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 import hashlib
 

--- a/Processors/StringSplitter.py
+++ b/Processors/StringSplitter.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["StringSplitter"]

--- a/Processors/StringSplitter.py
+++ b/Processors/StringSplitter.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["StringSplitter"]


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.