### PR TITLE
Deprecate QGIS recipes

### DIFF
--- a/QGIS/QGIS.download.recipe
+++ b/QGIS/QGIS.download.recipe
@@ -17,9 +17,18 @@
         <string>QGIS</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the QGIS recipes in the mlbz521-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/QGIS/QGIS.download.recipe
+++ b/QGIS/QGIS.download.recipe
@@ -26,7 +26,7 @@
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
-                <string>Consider switching to the QGIS recipes in the mlbz521-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+                <string>Consider switching to the QGIS download recipe in the mlbz521-recipes repo. This recipe is deprecated and will be removed in the future.</string>
             </dict>
         </dict>
         <dict>

--- a/QGIS/QGIS.munki.recipe
+++ b/QGIS/QGIS.munki.recipe
@@ -45,7 +45,7 @@
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.robperc.download.QGIS</string>
+    <string>com.github.mlbz521.download.QGIS</string>
     <key>Process</key>
     <array>
         <dict>

--- a/QGIS/QGIS.munki.recipe
+++ b/QGIS/QGIS.munki.recipe
@@ -43,11 +43,20 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>ParentRecipe</key>
     <string>com.github.mlbz521.download.QGIS</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the QGIS munki recipe in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The non-functional QGIS.download recipe in this repository is not sufficiently distinct from its earlier counterpart in MLBZ521-recipes. This PR deprecates the QGIS.download recipe and points users to MLBZ521-recipes.

Same for QGIS.munki and its counterpart in dataJAR-recipes, which is more actively maintained.